### PR TITLE
zoneCreate/zoneRecreate/zoneDelete methods

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -15,14 +15,6 @@ type ApiClient struct {
 	client *resty.Client
 }
 
-type DefaultResponse struct {
-	Metadata Metadata
-	Status   string
-
-	Errors   []Error
-	Warnings []Error
-}
-
 func NewApiClient(url string, token string, limit int) *ApiClient {
 	c := &ApiClient{}
 

--- a/client/client.go
+++ b/client/client.go
@@ -15,6 +15,14 @@ type ApiClient struct {
 	client *resty.Client
 }
 
+type DefaultResponse struct {
+	Metadata Metadata
+	Status   string
+
+	Errors   []Error
+	Warnings []Error
+}
+
 func NewApiClient(url string, token string, limit int) *ApiClient {
 	c := &ApiClient{}
 

--- a/client/client_dns.go
+++ b/client/client_dns.go
@@ -43,7 +43,7 @@ func (c *Dns) ZonesFind(filter *RequestFilter) ([]model.ZoneObject, error) {
 
 type ZoneResponse struct {
 	Response model.ZoneObject
-	DefaultResponse
+	EmptyResponse
 }
 
 type ZoneCreateRecreateRequest struct {
@@ -110,13 +110,13 @@ type ZoneDeleteRequest struct {
 	ZoneName     string `json:"zoneName,omitempty"`
 }
 
-func (c *Dns) ZoneDelete(zreq ZoneDeleteRequest) (*DefaultResponse, error) {
+func (c *Dns) ZoneDelete(zreq ZoneDeleteRequest) (*EmptyResponse, error) {
 	resp, err := c.c.Update("dns", "zoneDelete", zreq)
 	if err != nil {
 		return nil, fmt.Errorf("zone delete: %s", err)
 	}
 
-	var r DefaultResponse
+	var r EmptyResponse
 	err = json.Unmarshal(resp.Body(), &r)
 	if err != nil {
 		return nil, fmt.Errorf("zone delete: %s", err)

--- a/client/client_dns.go
+++ b/client/client_dns.go
@@ -41,6 +41,48 @@ func (c *Dns) ZonesFind(filter *RequestFilter) ([]model.ZoneObject, error) {
 	return out, nil
 }
 
+type ZoneResponse struct {
+	Response model.ZoneObject
+	DefaultResponse
+}
+
+type ZoneCreateRecreateRequest struct {
+	ZoneConfig              model.ZoneConfigObject `json:"zoneConfig,omitempty"`
+	Records                 []model.RecordObject   `json:"records,omitempty"`
+	NameserverSetID         string                 `json:"nameserverSetId,omitempty"`
+	UseDefaultNameserverSet bool                   `json:"useDefaultNameserverSet,omitempty"`
+}
+
+func (c *Dns) ZoneCreate(zreq ZoneCreateRecreateRequest) (*ZoneResponse, error) {
+	resp, err := c.c.Update("dns", "zoneCreate", zreq)
+	if err != nil {
+		return nil, fmt.Errorf("zone create: %s", err)
+	}
+
+	var r ZoneResponse
+	err = json.Unmarshal(resp.Body(), &r)
+	if err != nil {
+		return nil, fmt.Errorf("zone create: %s", err)
+	}
+
+	return &r, nil
+}
+
+func (c *Dns) ZoneRecreate(zreq ZoneCreateRecreateRequest) (*ZoneResponse, error) {
+	resp, err := c.c.Update("dns", "zoneRecreate", zreq)
+	if err != nil {
+		return nil, fmt.Errorf("zone recreate: %s", err)
+	}
+
+	var r ZoneResponse
+	err = json.Unmarshal(resp.Body(), &r)
+	if err != nil {
+		return nil, fmt.Errorf("zone recreate: %s", err)
+	}
+
+	return &r, nil
+}
+
 type ZoneUpdateRequest struct {
 	ZoneConfig      model.ZoneConfigObject `json:"zoneConfig,omitempty"`
 	RecordsToAdd    []model.RecordObject   `json:"recordsToAdd,omitempty"`
@@ -48,26 +90,36 @@ type ZoneUpdateRequest struct {
 	RecordsToDelete []model.RecordObject   `json:"recordsToDelete,omitempty"`
 }
 
-type ZoneUpdateResponse struct {
-	Response model.ZoneObject
-
-	Metadata Metadata
-	Status   string
-
-	Errors   []Error
-	Warnings []Error
-}
-
-func (c *Dns) ZoneUpdate(zreq ZoneUpdateRequest) (*ZoneUpdateResponse, error) {
+func (c *Dns) ZoneUpdate(zreq ZoneUpdateRequest) (*ZoneResponse, error) {
 	resp, err := c.c.Update("dns", "zoneUpdate", zreq)
 	if err != nil {
-		return nil, fmt.Errorf("update: %s", err)
+		return nil, fmt.Errorf("zone update: %s", err)
 	}
 
-	var r ZoneUpdateResponse
+	var r ZoneResponse
 	err = json.Unmarshal(resp.Body(), &r)
 	if err != nil {
 		return nil, fmt.Errorf("zone update: %s", err)
+	}
+
+	return &r, nil
+}
+
+type ZoneDeleteRequest struct {
+	ZoneConfigID string `json:"zoneConfigId,omitempty"`
+	ZoneName     string `json:"zoneName,omitempty"`
+}
+
+func (c *Dns) ZoneDelete(zreq ZoneDeleteRequest) (*DefaultResponse, error) {
+	resp, err := c.c.Update("dns", "zoneDelete", zreq)
+	if err != nil {
+		return nil, fmt.Errorf("zone delete: %s", err)
+	}
+
+	var r DefaultResponse
+	err = json.Unmarshal(resp.Body(), &r)
+	if err != nil {
+		return nil, fmt.Errorf("zone delete: %s", err)
 	}
 
 	return &r, nil

--- a/client/request.go
+++ b/client/request.go
@@ -32,7 +32,7 @@ func (c *ApiClient) Iterate(data *[]interface{}, T interface{}, endpoint string,
 			return 0, fmt.Errorf("iterate failed: %s", err)
 		}
 
-		var currentPageBody Response
+		var currentPageBody DataResponse
 		err = json.Unmarshal(resp.Body(), &currentPageBody)
 		if err != nil {
 			return 0, fmt.Errorf("iterate failed: %s", err)

--- a/client/response.go
+++ b/client/response.go
@@ -13,14 +13,18 @@ type ResponseMetadata struct {
 	Type         string `json:"type,omitempty"`
 }
 
-type Response struct {
+type EmptyResponse struct {
 	Metadata Metadata `json:"metadata,omitempty"`
+	Status   string   `json:"status,omitempty"`
+	Errors   []Error  `json:"errors,omitempty"`
+	Warnings []Error  `json:"warnings,omitempty"`
+}
+
+type DataResponse struct {
+	EmptyResponse
 	Response struct {
 		ResponseMetadata
 
 		Data []map[string]interface{} `json:"data,omitempty"`
 	} `json:"response,omitempty"`
-
-	Status string  `json:"status,omitempty"`
-	Errors []Error `json:"errors,omitempty"`
 }


### PR DESCRIPTION
DefaultResponse in Client defined, can also be used for empty responses e.g. for zoneDelete
other Responses include DefaultResponse
ZoneUpdateResponse renamed to ZoneResponse because create/recreate/update all give the same response
